### PR TITLE
Propose cross-port "Mapper Friendly MBF21 + ID24" UDMF namespace

### DIFF
--- a/extensions/mbf21_id24.txt
+++ b/extensions/mbf21_id24.txt
@@ -118,7 +118,7 @@ Note: All <bool> fields default to false unless mentioned otherwise.
                                       //                            NOTE: ZDoom/DSDA UDMF uses a different field 'scrollfloormode'
       scroll_ceil_x = <float>;        // [Boom Special 250] X Scroll equivalent to Boom linedef length / 10. 
                                       //                    NOTE: ZDoom/DSDA UDMF uses different field 'xscrollceiling'
-      scroll_ceil_x = <float>;        // [Boom Special 250] Y Scroll equivalent to Boom linedef length / 10. 
+      scroll_ceil_y = <float>;        // [Boom Special 250] Y Scroll equivalent to Boom linedef length / 10. 
                                       //                    NOTE: ZDoom/DSDA UDMF uses different field 'yscrollceiling'
       scroll_ceil_type = <string>;    // [Boom Special 250] Ceil scroll mode: "none" (no scroll), "visual" (only scroll texture)
                                       //                    NOTE: ZDoom/DSDA UDMF uses a different field 'scrollceilingmode'

--- a/extensions/mbf21_id24.txt
+++ b/extensions/mbf21_id24.txt
@@ -77,57 +77,65 @@ Note: All <bool> fields default to false unless mentioned otherwise.
    linedef
    {
       // bits added in MBF21
-      blockplayers = <bool>;           // Line blocks players' movement.
-      blocklandmonsters = <bool>;      // Line blocks walking monsters' movement.
+      blockplayers = <bool>;          // Line blocks players' movement.
+      blocklandmonsters = <bool>;     // Line blocks walking monsters' movement.
       
       
       // easier use of features
-      transparent = <bool>;            // [Boom Special 260] true = line is transparent
-      tranmap = <string>;              // [Boom Special 260 - tranmap] Use with 'transparent' to use a specific TRANMAP
+      transparent = <bool>;           // [Boom Special 260] true = line is transparent (using Boom's default TRANMAP)
+      tranmap = <string>;             // [Boom Special 260 - TRANMAP case] Use with 'transparent' to use a specific TRANMAP
+                                      // NOTE: DSDA/ZDoom UDMF does not have tranmap support for transparency
    }
 
    sidedef
    {
       // easier use of features
-      xscroll  = <float>;              // [Boom Special 254] wall scrolling X speed in map units per tic.
-      yscroll  = <float>;              // [Boom Special 254] wall scrolling Y speed in map units per tic.
+      xscroll  = <float>;             // [Boom Special 254/255] wall scrolling X speed in map units per tic.
+      yscroll  = <float>;             // [Boom Special 254/255] wall scrolling Y speed in map units per tic.
+                                      //                        NOTE: Eternity UDMF does not have these scroll fields
    }
 
    sector
    {
       // bits added in MBF21
-      special = <integer>             // Now parses Bit 12 and 13 like MBF21 (see MBF21 spec)
+      special = <integer>;            // Now parses Bit 12 and 13 like MBF21 (see MBF21 spec)
       
       
       // easier use of features
       lightfloor = <integer>;         // [Boom Special 213] The floor's light level. Default is 0.
-      lightceiling = <integer>;       // [Boom Special 254] The ceiling's light level. Default is 0.
-      lightfloorabsolute = <bool>;    // [Boom Special 213 extension] true = 'lightfloor' is an absolute value. Default is
-                                      // relative to the owning sector's light level.
-      lightceilingabsolute = <bool>;  // [Boom Special 254 extension] true = 'lightceiling' is an absolute value. Default is
-                                      // relative to the owning sector's light level. 
+      lightfloorabsolute = <bool>;    // [Boom Special 213] true = 'lightfloor' is an absolute light value. 
+                                      //                    false = 'lightfloor' is relative to sector's 'light'
+      lightceiling = <integer>;       // [Boom Special 261] The ceiling's light level. Default is 0.
+      lightceilingabsolute = <bool>;  // [Boom Special 261] true = 'lightceiling' is an absolute light value. 
+                                      //                    false = 'lightceiling' is relative to sector's 'light'
       
-      xscrollfloor = <float>;         // [Boom Special 251/252/253] X map units per frame to scroll the floor. NOTE: Eternity uses different field 'scroll_floor_x'
-      yscrollfloor = <float>;         // [Boom Special 251/252/253] Y map units per frame to scroll the floor. NOTE: Eternity uses different field 'scroll_floor_y'
-      scrollfloormode = <integer>;    // Floor scroll mode bit mask (1 = scroll textures, 2 = carry static objects, 
-                                      // 4 = carry players, 8 = carry monsters. 
-                                      // NOTE: 2, 4, 8 must be set or cleared together to replicate Boom!)
-                                      // NOTE: Eternity uses a different field 'scroll_ceil_type'
-      xscrollceiling = <float>;       // [Boom Special 250] X map units per frame to scroll the ceiling. NOTE: Eternity uses different field 'scroll_ceil_x'
-      yscrollceiling = <float>;       // [Boom Special 250] Y map units per frame to scroll the ceiling. NOTE: Eternity uses different field 'scroll_ceil_y'
-      scrollceilingmode = <integer>;  // Ceiling scroll mode bit mask (1 = scroll textures, 2 - 4 ignored)
-                                      // Should be 1 if 'xscrollceiling' or 'yscrollceiling' are used.
+      scroll_floor_x = <float>;       // [Boom Special 251/252/253] X Scroll equivalent to Boom linedef length / 10. 
+                                      //                            NOTE: ZDoom/DSDA uses different field 'xscrollfloor'
+      scroll_floor_y = <float>;       // [Boom Special 251/252/253] Y Scroll equivalent to Boom linedef length / 10. 
+                                      //                            NOTE: ZDoom/DSDA uses different field 'yscrollfloor'
+      scroll_floor_type = <string>;   // [Boom Special 251/252/253] Floor scroll mode: "none" (no scroll), "visual" (only scroll texture), 
+                                      //                            "physical" (only carry the things), "both" (both scroll and carry)
+                                      //                            NOTE: ZDoom/DSDA UDMF uses a different field 'scrollfloormode'
+      scroll_ceil_x = <float>;        // [Boom Special 250] X Scroll equivalent to Boom linedef length / 10. 
+                                      //                    NOTE: ZDoom/DSDA UDMF uses different field 'xscrollceiling'
+      scroll_ceil_x = <float>;        // [Boom Special 250] Y Scroll equivalent to Boom linedef length / 10. 
+                                      //                    NOTE: ZDoom/DSDA UDMF uses different field 'yscrollceiling'
+      scroll_ceil_type = <string>;    // [Boom Special 250] Ceil scroll mode: "none" (no scroll), "visual" (only scroll texture)
+                                      //                    NOTE: ZDoom/DSDA UDMF uses a different field 'scrollceilingmode'
         
       friction = <integer>;           // [Boom Special 223] sets the sector's friction as if it were the line length for Boom friction.
-                                      // (Eternity already uses the field this way)
+                                      //                    NOTE: This is Eternity UDMF's version, ZDoom/DSDA have different friction fields
       
       xthrust = <float>;              // [Boom Special 224/225] applies thrust to actors - x-magnitude
       ythrust = <float>;              // [Boom Special 224/225] applies thrust to actors - y-magnitude
-      thrustlocation = <int>;         // [Boom Special 224/225] specifies where in the sector actors get thrusted: 
-                                      // 1 = on the ground (Boom current), 2 = in the air (Boom wind), 4 = this bit ignored
+      thrustlocation = <integer>;     // [Boom Special 224/225] Bitfield specifies whether the thrust is 
+                                      //                        "Boom Current (Special 225)" or "Boom Wind (Special 224)"
+                                      //                        value 1 = Boom current, value 2 = Boom wind
+                                      // NOTE: Eternity UDMF does not have these thrust fields
       
       skyfloor = <string>;            // [MBF Special 271] sets the sky texture used in this sector's floor
-      skyceiling = <string>           // [MBF Special 271] sets the sky texture used in this sector's ceiling
+      skyceiling = <string>;          // [MBF Special 271] sets the sky texture used in this sector's ceiling
+                                      // NOTE: Eternity UDMF has no sky fields. Use ID24 SKYDEFS (sky based on flat) instead?
                                       
       xpanningfloor = <float>;        // [ID24 Special 2048] X texture offset of floor texture, Default = 0.0.
       ypanningfloor = <float>;        // [ID24 Special 2048] Y texture offset of floor texture, Default = 0.0.
@@ -138,6 +146,7 @@ Note: All <bool> fields default to false unless mentioned otherwise.
       
       colormap = <string>;            // [ID24 Special 2075] sets the colormap this sector is drawn with. ID24/ZDoom style, not Boom style
                                       // (sector color is visible from any sector, not only when standing in the sector)
+                                      // NOTE: GZDoom discourages use of colormap and it is unclear whether Eternity's is Boom style or not
    }
 
    thing
@@ -168,19 +177,21 @@ Note: All <bool> fields default to false unless mentioned otherwise.
       yscrollbottom  = <float>;        // [Boom Special 254 extension] lower wall scrolling Y speed in map units per tic.
                                        
       light = <integer>;               // This side's light level. Default is 0.
-      lightabsolute = <bool>;          // true = 'light' is an absolute value. Default is 
-                                       // relative to the owning sector's light level.
+      lightabsolute = <bool>;          // true = 'light' is an absolute value. 
+                                       // Default is relative to the owning sector's light level.
       light_top = <integer>;           // This side's top tier light level. Default is 0.
-      lightabsolute_top = <bool>;      // true = 'light_top' is an absolute value. Default is
-                                       // relative to the sidedef's resulting light level.
+      lightabsolute_top = <bool>;      // true = 'light_top' is an absolute value. 
+                                       // Default is relative to the sidedef's resulting light level.
       light_mid = <integer>;           // This side's mid tier light level. Default is 0.
-      lightabsolute_mid = <bool>;      // true = 'light_mid' is an absolute value. Default is
-                                       // relative to the sidedef's resulting light level.
+      lightabsolute_mid = <bool>;      // true = 'light_mid' is an absolute value. 
+                                       // Default is to the sidedef's resulting light level.
       light_bottom = <integer>;        // This side's bottom tier light level. Default is 0.
-      lightabsolute_bottom = <bool>;   // true = 'light_bottom' is an absolute value. Default is
-                                       // relative to the sidedef's resulting light level.
+      lightabsolute_bottom = <bool>;   // true = 'light_bottom' is an absolute value. 
+                                       // Default isto the sidedef's resulting light level.
+
       nofakecontrast = <bool>;         // Disables use of fake contrast on this sidedef.
       smoothlighting = <bool>;         // Use smooth fake contrast.
+
       clipmidtex = <bool>;             // Side's mid textures are clipped to floor and ceiling.
       wrapmidtex = <bool>;             // Side's mid textures are wrapped.
    }
@@ -188,7 +199,8 @@ Note: All <bool> fields default to false unless mentioned otherwise.
    sector
    {    
       // man this would be awesome
-      moreids = <string>;             // Additional sector IDs/tags, specified as a space separated list of numbers (e.g. "2 666 1003 4505")
+      moreids = <string>;             // Additional sector IDs/tags, specified as a space separated list of numbers 
+                                      // (e.g. "2 666 1003 4505")
    }
 
 =======================================

--- a/extensions/mbf21_id24.txt
+++ b/extensions/mbf21_id24.txt
@@ -111,7 +111,7 @@ Note: All <bool> fields default to false unless mentioned otherwise.
                                       // NOTE: Eternity uses a different field 'scroll_ceil_type'
       xscrollceiling = <float>;       // [Boom Special 250] X map units per frame to scroll the ceiling. NOTE: Eternity uses different field 'scroll_ceil_x'
       yscrollceiling = <float>;       // [Boom Special 250] Y map units per frame to scroll the ceiling. NOTE: Eternity uses different field 'scroll_ceil_y'
-      scrollfloormode = <integer>;    // Ceiling scroll mode bit mask (1 = scroll textures, 2 - 4 ignored)
+      scrollceilingmode = <integer>;  // Ceiling scroll mode bit mask (1 = scroll textures, 2 - 4 ignored)
                                       // Should be 1 if 'xscrollceiling' or 'yscrollceiling' are used.
         
       friction = <integer>;           // [Boom Special 223] sets the sector's friction as if it were the line length for Boom friction.

--- a/extensions/mbf21_id24.txt
+++ b/extensions/mbf21_id24.txt
@@ -1,0 +1,204 @@
+===============================================================================
+Universal Doom Map Format MBF21/ID24 extensions v0.1 2026-05-17
+
+
+    Copyright (c) 2026 Doom Cross-Port Collaboration Team
+    Permission is granted to copy, distribute and/or modify this document
+    under the terms of the GNU Free Documentation License, Version 1.2
+    or any later version published by the Free Software Foundation;
+    with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+    
+===============================================================================
+
+This document discusses only the additions mbf21_id24 makes to the UDMF 
+specification.
+
+=======================================
+I. Grammar / Syntax
+=======================================
+
+    No changes.
+
+=======================================
+II. Implementation Semantics
+=======================================
+
+------------------------------------
+II.A : Storage and Retrieval of Data
+------------------------------------
+
+    No changes.
+
+-----------------------------------
+II.B : Storage Within Archive Files
+-----------------------------------
+
+    No changes.
+    
+--------------------------------
+II.C : Implementation Dependence
+--------------------------------
+
+The new namespace "mbf21_id24" is built upon the "Doom" UDMF base specification.
+
+Doom-type (non-parameterized) line specials are used.
+
+All line specials from Vanilla Doom, Boom, MBF, MBF21, and ID24 are expected to be supported.
+
+Additionally, the line special '1080' with tag '180' is to be interpreted as a "Line Horizon"
+effect, which draws the floor and ceiling out into infinity.
+The purpose is to restore ZokumBSP's line special 1080 effect, which can be used in the vanilla
+map nodes format, but cannot be used in ZDBSP extended nodes formats due to their lack of a
+dedicated segs angle field.
+
+Boom generalized crusher walkover lines and 6-key locked doors are expected to be fixed, like in MBF21.
+
+
+=======================================
+III. Standardized Fields
+=======================================
+
+"mbf21_id24" namespace implements all Doom fields from the base standard.
+No additional support is added for the Heretic/Hexen/Strife exclusive base-spec fields.
+
+In addition to the standard fields, "mbf21_id24" defines additional fields.
+Some implement the additional flags and specials from MBF21, while the rest make it much 
+easier for a mapper to directly use mapping features added by Boom, MBF, MBF21, and ID24, rather
+than having to use tags, remote line specials, and control sectors to set them up. (Such as making
+conveyors)
+
+Note: All <bool> fields default to false unless mentioned otherwise.
+
+   vertex
+   {
+      // No changes.
+   }
+
+   linedef
+   {
+      // bits added in MBF21
+      blockplayers = <bool>;           // Line blocks players' movement.
+      blocklandmonsters = <bool>;      // Line blocks walking monsters' movement.
+      
+      
+      // easier use of features
+      transparent = <bool>;            // [Boom Special 260] true = line is transparent
+      tranmap = <string>;              // [Boom Special 260 - tranmap] Use with 'transparent' to use a specific TRANMAP
+   }
+
+   sidedef
+   {
+      // easier use of features
+      xscroll  = <float>;              // [Boom Special 254] wall scrolling X speed in map units per tic.
+      yscroll  = <float>;              // [Boom Special 254] wall scrolling Y speed in map units per tic.
+   }
+
+   sector
+   {
+      // bits added in MBF21
+      special = <integer>             // Now parses Bit 12 and 13 like MBF21 (see MBF21 spec)
+      
+      
+      // easier use of features
+      lightfloor = <integer>;         // [Boom Special 213] The floor's light level. Default is 'light' value.
+      lightceiling = <integer>;       // [Boom Special 254] The ceiling's light level. Default is 'light' value.
+      
+      xscrollfloor = <float>;         // [Boom Special 251/252/253] X map units per frame to scroll the floor. NOTE: Eternity uses different field 'scroll_floor_x'
+      yscrollfloor = <float>;         // [Boom Special 251/252/253] Y map units per frame to scroll the floor. NOTE: Eternity uses different field 'scroll_floor_y'
+      scrollfloormode = <integer>;    // Floor scroll mode bit mask (1 = scroll textures, 2 = carry static objects, 
+                                      // 4 = carry players, 8 = carry monsters. 
+                                      // NOTE: 2, 4, 8 must be set or cleared together to replicate Boom!)
+                                      // NOTE: Eternity uses a different field 'scroll_ceil_type'
+      xscrollceiling = <float>;       // [Boom Special 250] X map units per frame to scroll the ceiling. NOTE: Eternity uses different field 'scroll_ceil_x'
+      yscrollceiling = <float>;       // [Boom Special 250] Y map units per frame to scroll the ceiling. NOTE: Eternity uses different field 'scroll_ceil_y'
+      scrollfloormode = <integer>;    // Ceiling scroll mode bit mask (1 = scroll textures, 2 - 4 ignored)
+                                      // Should be 1 if 'xscrollceiling' or 'yscrollceiling' are used.
+        
+      friction = <integer>;           // [Boom Special 223] sets the sector's friction as if it were the line length for Boom friction.
+                                      // (Eternity already uses the field this way)
+      
+      xthrust = <float>;              // [Boom Special 224/225] applies thrust to actors - x-magnitude
+      ythrust = <float>;              // [Boom Special 224/225] applies thrust to actors - y-magnitude
+      thrustlocation = <int>;         // [Boom Special 224/225] specifies where in the sector actors get thrusted: 
+                                      // 1 = on the ground (Boom current), 2 = in the air (Boom wind), 4 = this bit ignored
+      
+      skyfloor = <string>;            // [MBF Special 271] sets the sky texture used in this sector's floor
+      skyceiling = <string>           // [MBF Special 271] sets the sky texture used in this sector's ceiling
+                                      
+      xpanningfloor = <float>;        // [ID24 Special 2048] X texture offset of floor texture, Default = 0.0.
+      ypanningfloor = <float>;        // [ID24 Special 2048] Y texture offset of floor texture, Default = 0.0.
+      xpanningceiling = <float>;      // [ID24 Special 2049] X texture offset of ceiling texture, Default = 0.0.
+      ypanningceiling = <float>;      // [ID24 Special 2049] Y texture offset of ceiling texture, Default = 0.0.
+      rotationfloor = <float>;        // [ID24 Special 2051] Rotation of floor texture in degrees, Default = 0.0.
+      rotationceiling = <float>;      // [ID24 Special 2052] Rotation of ceiling texture in degrees, Default = 0.0.
+      
+      colormap = <string>;            // [ID24 Special 2075] sets the colormap this sector is drawn with. ID24/ZDoom style, not Boom style
+                                      // (sector color is visible from any sector, not only when standing in the sector)
+   }
+
+   thing
+   {
+      // no changes
+   }
+   
+   
+   Below are even more proposed fields, which are some common extensions used across ZDoom, Eternity,
+   and DSDA namespaces, and therefore should be easy adds.
+   
+   sidedef
+   {
+      offsetx_top = <float>;           // X offset for upper texture, Default = 0.0.
+      offsety_top = <float>;           // Y offset for upper texture, Default = 0.0.
+      offsetx_mid = <float>;           // X offset for mid texture, Default = 0.0.
+      offsety_mid = <float>;           // Y offset for mid texture, Default = 0.0.
+      offsetx_bottom = <float>;        // X offset for lower texture, Default = 0.0.
+      offsety_bottom = <float>;        // Y offset for lower texture, Default = 0.0.
+                                       // When global texture offsets are used they will
+                                       // be added on top of these values.
+                                       
+      xscrolltop  = <float>;           // [Boom Special 254 extension] upper wall scrolling X speed in map units per tic.
+      yscrolltop  = <float>;           // [Boom Special 254 extension] upper wall scrolling Y speed in map units per tic.
+      xscrollmid  = <float>;           // [Boom Special 254 extension] mid wall scrolling X speed in map units per tic.
+      yscrollmid  = <float>;           // [Boom Special 254 extension] mid wall scrolling Y speed in map units per tic.
+      xscrollbottom  = <float>;        // [Boom Special 254 extension] lower wall scrolling X speed in map units per tic.
+      yscrollbottom  = <float>;        // [Boom Special 254 extension] lower wall scrolling Y speed in map units per tic.
+                                       
+      light = <integer>;               // This side's light level. Default is 0.
+      lightabsolute = <bool>;          // true = 'light' is an absolute value. Default is 
+                                       // relative to the owning sector's light level.
+      light_top = <integer>;           // This side's top tier light level. Default is 0.
+      lightabsolute_top = <bool>;      // true = 'light_top' is an absolute value. Default is
+                                       // relative to the sidedef's resulting light level.
+      light_mid = <integer>;           // This side's mid tier light level. Default is 0.
+      lightabsolute_mid = <bool>;      // true = 'light_mid' is an absolute value. Default is
+                                       // relative to the sidedef's resulting light level.
+      light_bottom = <integer>;        // This side's bottom tier light level. Default is 0.
+      lightabsolute_bottom = <bool>;   // true = 'light_bottom' is an absolute value. Default is
+                                       // relative to the sidedef's resulting light level.
+      nofakecontrast = <bool>;         // Disables use of fake contrast on this sidedef.
+      smoothlighting = <bool>;         // Use smooth fake contrast.
+      clipmidtex = <bool>;             // Side's mid textures are clipped to floor and ceiling.
+      wrapmidtex = <bool>;             // Side's mid textures are wrapped.
+   }
+   
+   sector
+   {
+      lightfloorabsolute = <bool>;    // [Boom Special 213 extension] true = 'lightfloor' is an absolute value. Default is
+                                      // relative to the owning sector's light level.
+      lightceilingabsolute = <bool>;  // [Boom Special 254 extension] true = 'lightceiling' is an absolute value. Default is
+                                      // relative to the owning sector's light level. 
+      
+      // man this would be awesome
+      moreids = <string>;             // Additional sector IDs/tags, specified as a space separated list of numbers (e.g. "2 666 1003 4505")
+   }
+
+=======================================
+Changelog
+=======================================
+
+0.1 2026-05-17
+Initial proposal of "mbf21_id24" namespace
+
+===============================================================================
+EOF
+===============================================================================

--- a/extensions/mbf21_id24.txt
+++ b/extensions/mbf21_id24.txt
@@ -100,8 +100,12 @@ Note: All <bool> fields default to false unless mentioned otherwise.
       
       
       // easier use of features
-      lightfloor = <integer>;         // [Boom Special 213] The floor's light level. Default is 'light' value.
-      lightceiling = <integer>;       // [Boom Special 254] The ceiling's light level. Default is 'light' value.
+      lightfloor = <integer>;         // [Boom Special 213] The floor's light level. Default is 0.
+      lightceiling = <integer>;       // [Boom Special 254] The ceiling's light level. Default is 0.
+      lightfloorabsolute = <bool>;    // [Boom Special 213 extension] true = 'lightfloor' is an absolute value. Default is
+                                      // relative to the owning sector's light level.
+      lightceilingabsolute = <bool>;  // [Boom Special 254 extension] true = 'lightceiling' is an absolute value. Default is
+                                      // relative to the owning sector's light level. 
       
       xscrollfloor = <float>;         // [Boom Special 251/252/253] X map units per frame to scroll the floor. NOTE: Eternity uses different field 'scroll_floor_x'
       yscrollfloor = <float>;         // [Boom Special 251/252/253] Y map units per frame to scroll the floor. NOTE: Eternity uses different field 'scroll_floor_y'
@@ -182,12 +186,7 @@ Note: All <bool> fields default to false unless mentioned otherwise.
    }
    
    sector
-   {
-      lightfloorabsolute = <bool>;    // [Boom Special 213 extension] true = 'lightfloor' is an absolute value. Default is
-                                      // relative to the owning sector's light level.
-      lightceilingabsolute = <bool>;  // [Boom Special 254 extension] true = 'lightceiling' is an absolute value. Default is
-                                      // relative to the owning sector's light level. 
-      
+   {    
       // man this would be awesome
       moreids = <string>;             // Additional sector IDs/tags, specified as a space separated list of numbers (e.g. "2 666 1003 4505")
    }


### PR DESCRIPTION
There has been interest in developing a cross-port UDMF namespace which fulfills the following goals:
- More features than the current "doom" base UDMF namespace
- Less features than the DSDA/Eternity/ZDoom UDMF namespaces to make it easy for ports to universally support
- More conservative in scope - no Hexen stuff; familiar to people who have been making binary-style Doom/Boom maps
- Encourage mappers to try UDMF without worrying about the many port-specific features available in the other namespaces

To that end, here is a proposal for a namespace based on the MBF21 and ID24 feature set, which adds fields to make the usage of most Boom, MBF, and ID24 features a lot easier for mappers (such as setting scroller values directly in the sector rather than having to set up a line action + tag to do it). This should get people more willing to try UDMF than a basic MBF21 namespace which still requires using line actions and tags to do everything.

Check the "Files changed" tab above to read the proposal.

The boom/mbf/mbf21/id24 specials that are effectively deprecated by the extra fields should still be supported. This is to make it easier to migrate a map from binary to this UDMF namespace, and to make this namespace not require a different workflow. Properties set using these specials should override ones set using the new sector/Sidedef fields.

Nearly all of the proposed new fields are already used in the ZDoom, Eternity, and DSDA namespaces (exceptions/differences noted in txt) which should make this namespace favorable for easy implementation.

I think staying with the existing Doom-styled (non parameterized) Doom+Boom+MBF+MBF21+ID24 line specials should be a requirement. It's a much smaller ask for any ports which have not dealt with adding Hexen-style parameterized alternate specials yet, and they've probably added the Boom & MBF specials already. The only new special proposed is "Line Horizon", which replicates a ZokumBSP effect that is usable in vanilla map format but not usable in UDMF's required XGL2/3 formats.

Additionally, later in the document is a block of additional proposed fields which are common in the other UDMF namespaces. These are features some directly associate with UDMF, such as separate offsets for upper/lower textures. 

As for: Why ID24 and why not stop at MBF21? The main reason is that once you add several expected UDMF features (such as sector floor offset and rotation, or independent wall scroller values for front/back sides) to MBF21, you've already added most of the mapping features that ID24 adds, so might as well go all the way since it's there. Even if it is decided that ID24 line specials should not be required, the proposed UDMF fields based on them should remain due to their utility as well as ubiquity in the other UDMF namespaces.

As for: What about MBF2Y? I think that can probably be its own namespace once it is ready, unless all of its mapping additions are very similar to what is here, or are fairly trivial additions for a port author.

The name "mbf21_id24" or "Mapper Friendly MBF21 + ID24" is very not locked in. I just feel it best represents the features included. I don't think the name necessarily even needs to include the terms MBF21 or ID24. The idea is simply that this namespace is a best representation of the current state of the Boom lineage.

All feedback is welcome.

tl;dr Here is a cross-port UDMF namespace that is an even smaller subset of zdoom/eternity/dsda namespace, which depends only on existing Doom stuff and has no Hexen stuff, so that any port can support it easily